### PR TITLE
removing minio credential from the build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,6 @@
 FROM python:3.7-buster
 
 ENV TZ=America/Toronto
-ENV MINIO_USERNAME=minioadmin
-ENV MINIO_PASSWORD=minioadmin
 
 WORKDIR /usr/src/app
 
@@ -36,5 +34,8 @@ RUN poetry config virtualenvs.create false
 RUN poetry install --no-root --no-interaction
 COPY . ./
 
+ENV MINIO_USERNAME=minioadmin
+ENV MINIO_PASSWORD=minioadmin
+ENV MINIO_URL=http://minio.minio:9000
 RUN chmod +x gunicorn_starter.sh
-CMD ["sh", "-c", "mc alias set minio http://minio.minio:9000 $MINIO_USERNAME $MINIO_PASSWORD && ./gunicorn_starter.sh"]
+CMD ["sh", "-c", "mc alias set minio $MINIO_URL $MINIO_USERNAME $MINIO_PASSWORD && ./gunicorn_starter.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,12 +14,10 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 FROM python:3.7-buster
-ARG MINIO_USERNAME
-ARG MINIO_PASSWORD
 
 ENV TZ=America/Toronto
-ENV MINIO_USERNAME=$MINIO_USERNAME
-ENV MINIO_PASSWORD=$MINIO_PASSWORD
+ENV MINIO_USERNAME=minioadmin
+ENV MINIO_PASSWORD=minioadmin
 
 WORKDIR /usr/src/app
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,11 +43,9 @@ pipeline {
       when {branch "develop"}
       steps {
         script {
-            withCredentials([
-                usernamePassword(credentialsId:'minio', usernameVariable: 'MINIO_USERNAME', passwordVariable: 'MINIO_PASSWORD')
-          ]) {
+           {
             docker.withRegistry('https://ghcr.io', registryCredential) {
-                customImage = docker.build("$imagename:$commit", "--build-arg MINIO_USERNAME=$MINIO_USERNAME --build-arg MINIO_PASSWORD=$MINIO_PASSWORD .")
+                customImage = docker.build("$imagename:$commit", ".")
                 customImage.push()
             }
           }


### PR DESCRIPTION
## Summary

This will remove the need to have the MINIO password in the build time and will get that credential from Kubernetes secrets.

## JIRA Issues

https://indocconsortium.atlassian.net/browse/PILOT-1077 

## Type of Change

Please delete options that are not relevant.

- [x] Improvement


## Testing

Are there any new or updated tests to validate the changes?

- [ ] Yes
- [x] No

