### PR TITLE
fix files wrong classified as duplicated files/folders

### DIFF
--- a/app/routers/v1/dataset_file.py
+++ b/app/routers/v1/dataset_file.py
@@ -406,6 +406,7 @@ class APIImportData:
         passed_file = []
         not_passed_file = []
         duplicate_in_batch_dict = {}
+
         obj_list = await MetadataClient.get_objects(code, items_type=items_type)
         # creates dict where key is obj.id and value is root_objects index
         object_ids = {obj['id']: obj_list.index(obj) for obj in obj_list}
@@ -481,11 +482,13 @@ class APIImportData:
         duplic_file = []
         not_duplic_file = []
         name_parent_dict = {obj['name']: obj['parent_path'] for obj in dataset_objects}
+        type_dict = {obj['name']: obj['type'] for obj in dataset_objects}
         for file in files_list:
             same_name = name_parent_dict.get(file.get('name'), 'not_found')
+            obj_type = type_dict.get(file.get('name'), 'not_found')
             if same_name == 'not_found':
                 not_duplic_file.append(file)
-            elif same_name == file.get('parent_path'):
+            elif same_name == file.get('parent_path') and obj_type == file.get('type'):
                 file.update({'feedback': 'duplicate or unauthorized'})
                 duplic_file.append(file)
             else:

--- a/tests/dataset_file/test_rename_file.py
+++ b/tests/dataset_file/test_rename_file.py
@@ -157,6 +157,7 @@ async def test_rename_file_should_add_file_to_ignoring_when_file_duplicated_and_
                     'name': 'new_name',
                     'parent': None,
                     'parent_path': None,
+                    'type': 'file',
                 },
             ]
         },


### PR DESCRIPTION
## Summary

files with the same `parent_path` and name but a different `type` are not considered duplicated

## JIRA Issues

---

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactor or reformatting

## Testing

Are there any new or updated tests to validate the changes?

- [x] Yes
- [ ] No

## Test Directions

(Additional instructions for how to run tests or validate functionality if not covered by unit tests)
